### PR TITLE
Adding reqheaders options into nock.Options for intercepting header

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,7 @@ declare namespace nock {
 
   export interface Options {
     allowUnmocked?: boolean;
+    reqheaders:Object
   }
 
   export interface RecorderOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare namespace nock {
 
   export interface Options {
     allowUnmocked?: boolean;
-    reqheaders:Object
+    reqheaders?: Object;
   }
 
   export interface RecorderOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare namespace nock {
 
   export interface Options {
     allowUnmocked?: boolean;
-    reqheaders?: Object;
+    reqheaders?: { [key: string]: any };
   }
 
   export interface RecorderOptions {


### PR DESCRIPTION
Hi,

I wanted to intercept when Allow-Control-Access-Origin and nock api use reqheaders in options so I added it as it was missing or not up to date.
