### PR TITLE
add reply method options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -117,6 +117,7 @@ declare namespace nock {
     query (acceptAnyParams: boolean): Scope;
 
     reply (statusCode: number, body?: string | Object, headers?: Object): Scope;
+    reply (fn: (uri: string, requestBody: string | Object, cb: (err: Error, response: any[]) => void) => void | any[]): Scope;
     replyWithFile (statusCode: number, fileName: string): Scope;
     replyWithError (error: string | Object): Scope;
 


### PR DESCRIPTION
nock allows .reply to use a function as first argument in reply.  Added the line to support that for these examples in [nock README](https://github.com/node-nock/nock#specifying-replies)

---

You can also return the status code and body using just one function:

``` js
var scope = nock('http://www.google.com')
   .filteringRequestBody(/.*/, '*')
   .post('/echo', '*')
   .reply(function(uri, requestBody) {
     return [
       201,
       'THIS IS THE REPLY BODY',
       {'header': 'value'} // optional headers
     ];
   });
```

or, use an error-first callback that also gets the status code:

``` js
var scope = nock('http://www.google.com')
   .filteringRequestBody(/.*/, '*')
   .post('/echo', '*')
   .reply(function(uri, requestBody, cb) {
     setTimeout(function() {
       cb(null, [201, 'THIS IS THE REPLY BODY'])
     }, 1e3);
   });
```

If you're using the reply callback style, you can access the original client request using `this.req`  like this:

``` js
var scope = nock('http://www.google.com')
   .get('/cat-poems')
   .reply(function(uri, requestBody) {
     console.log('path:', this.req.path);
     console.log('headers:', this.req.headers);
     // ...
   });
```
